### PR TITLE
ng_both_txrx: simplified Makefile slightly

### DIFF
--- a/examples/ng_both_txrx/Makefile
+++ b/examples/ng_both_txrx/Makefile
@@ -26,19 +26,11 @@ export ATRF_SLEEP ?= GPIO_14
 USEMODULE += vtimer
 USEMODULE += ps
 
-USEMODULE += auto_init_ng_netif
-USEMODULE += ng_at86rf231
 USEMODULE += ng_netif
-USEMODULE += ng_netapi
-USEMODULE += ng_netreg
-USEMODULE += ng_pktbuf
-USEMODULE += ng_netif_hdr
-USEMODULE += ng_netbase
-USEMODULE += ng_nomac
-USEMODULE += ng_ipv6
+USEMODULE += auto_init_ng_netif
+USEMODULE += ng_ipv6_default
 USEMODULE += ng_udp
 USEMODULE += ng_pktdump
-USEMODULE += ng_ndp
 
 ifneq (,$(ATRF_SPI))
   CFLAGS += -DATRF_SPI=$(ATRF_SPI)

--- a/examples/ng_both_txrx/main.c
+++ b/examples/ng_both_txrx/main.c
@@ -292,11 +292,8 @@ int main(void)
         // send packet (NG_NETREG_DEMUX_CTX_ALL: no limitations about the finding)
         sendto = ng_netreg_lookup(NG_NETTYPE_UDP, NG_NETREG_DEMUX_CTX_ALL);
 
-        ng_pktbuf_hold(ip, ng_netreg_num(NG_NETTYPE_UDP,
-                                     NG_NETREG_DEMUX_CTX_ALL) - 1);
         ng_netapi_send(sendto->pid, ip);
 
-        ng_pktbuf_release(ip);
         iter++;
 
         vtimer_usleep(2000*1000);


### PR DESCRIPTION
Just simplified the used modules. When looking at the modules actually used during compile time, the only difference is, that `ng_sixlowpan_frag` is now included. But no idea if this helps or not... 